### PR TITLE
KeyFieldInfo APIs

### DIFF
--- a/include/tdi/common/tdi_json_parser/tdi_table_info.hpp
+++ b/include/tdi/common/tdi_json_parser/tdi_table_info.hpp
@@ -365,7 +365,14 @@ class KeyFieldInfo {
    *
    * @return Field Size in bits
    */
-  const size_t &sizeGet() const;
+  const size_t &sizeGet() const { return size_bits_; };
+
+  /**
+   * @brief Is field Slice
+   *
+   * @return if the key is a field slice
+   */
+  const bool &isFieldSlice() const { return is_field_slice_; };
 
   /**
    * @brief Get whether Key Field is of type ptr or not. If the field is

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ set(TDI_C_FRONTEND_SRCS
 add_library(tdi_o OBJECT ${TDI_SRCS} ${TDI_C_FRONTEND_SRCS})
 add_library(tdi SHARED $<TARGET_OBJECTS:tdi_o>)
 
-target_link_libraries(tdi PUBLIC target_utils target_sys)
+target_link_libraries(tdi PUBLIC target_utils target_sys tdi_json_parser)
 
 add_subdirectory(arch/tna)
 add_subdirectory(targets/dummy)


### PR DESCRIPTION
Key_field width and is_field_slice needed by context parsing