### PR TITLE
API changes and additions

### DIFF
--- a/include/tdi/arch/tna/tna_defs.h
+++ b/include/tdi/arch/tna/tna_defs.h
@@ -50,9 +50,14 @@ typedef enum {
  * @brief Key Field Match Type. A key can have multiple fields,
  * each with a different match type
  */
-enum tdi_match_type_tna_e {
-  TDI_MATCH_TYPE_TNA_RANGE = TDI_MATCH_TYPE_ARCH,
-  TDI_MATCH_TYPE_TNA_ATCAM,
+enum tdi_tna_match_type_e {
+  TDI_TNA_MATCH_TYPE_RANGE = TDI_MATCH_TYPE_ARCH,
+  TDI_TNA_MATCH_TYPE_ATCAM,
+};
+
+enum tdi_tna_target_e {
+  TDI_TNA_TARGET_PIPE_ID = TDI_TARGET_ARCH,
+  TDI_TNA_TARGET_DIRECTION,
 };
 
 #ifdef __cplusplus

--- a/include/tdi/arch/tna/tna_info.hpp
+++ b/include/tdi/arch/tna/tna_info.hpp
@@ -54,9 +54,9 @@ class TdiInfoMapper : public tdi::TdiInfoMapper {
   TdiInfoMapper() {
     // Match types
     matchEnumMapAdd(tdi_json::values::tna::ATCAM,
-                    static_cast<tdi_match_type_e>(TDI_MATCH_TYPE_TNA_ATCAM));
+                    static_cast<tdi_match_type_e>(TDI_TNA_MATCH_TYPE_ATCAM));
     matchEnumMapAdd(tdi_json::values::tna::RANGE,
-                    static_cast<tdi_match_type_e>(TDI_MATCH_TYPE_TNA_RANGE));
+                    static_cast<tdi_match_type_e>(TDI_TNA_MATCH_TYPE_RANGE));
   }
 };
 
@@ -67,6 +67,7 @@ class TdiInfoMapper : public tdi::TdiInfoMapper {
 class TableFactory : public tdi::TableFactory {
  public:
   virtual std::unique_ptr<tdi::Table> makeTable(
+      const TdiInfo * /*tdi_info*/,
       const tdi::TableInfo * /*table_info*/) const override {
     // No tables in TNA currently. Will eventually have Selector, Action profile
     // etc

--- a/include/tdi/arch/tna/tna_target.hpp
+++ b/include/tdi/arch/tna/tna_target.hpp
@@ -36,11 +36,6 @@ namespace tna {
 
 class Device;
 
-enum tna_target_e {
-  TNA_TARGET_PIPE_ID = TDI_TARGET_ARCH,
-  TNA_TARGET_DIRECTION,
-};
-
 /**
  * @brief Can be constructed by \ref tna::Device::createTarget()
  */
@@ -48,22 +43,20 @@ class Target : public tdi::Target {
  public:
   virtual ~Target() = default;
   virtual tdi_status_t setValue(const tdi_target_e & /*target*/,
-                        const uint32_t & /*value*/) override;
+                                const uint32_t & /*value*/) override;
   virtual tdi_status_t getValue(const tdi_target_e & /*target*/,
-                        uint32_t * /*value*/) override;
+                                uint32_t * /*value*/) const override;
 
  protected:
-  Target(const tdi_dev_id_t &dev_id,
-         const tna_pipe_id_t &pipe_id,
-         const tna_direction_e& direction) :
-    tdi::Target(dev_id), pipe_id_(pipe_id), direction_(direction){};
- private:
-  friend class tdi::tna::Device;
+  Target(tdi_dev_id_t dev_id, tna_pipe_id_t pipe_id, tna_direction_e direction)
+      : tdi::Target(dev_id), pipe_id_(pipe_id), direction_(direction){};
   tna_pipe_id_t pipe_id_;
   tna_direction_e direction_;
+
+  friend class tdi::tna::Device;
 };
 
-}  // tna
-}  // tdi
+}  // namespace tna
+}  // namespace tdi
 
 #endif  // _TNA_DEFS_HPP_

--- a/include/tdi/common/tdi_defs.h
+++ b/include/tdi/common/tdi_defs.h
@@ -107,9 +107,9 @@ enum tdi_field_data_type_e {
 };
 
 /**
-* @brief P4 Arch types. If any new p4 arch needs to be
-* used not currently known by TDI, then use TDI_ARCH_TYPE_UNKNOWN
-*/
+ * @brief P4 Arch types. If any new p4 arch needs to be
+ * used not currently known by TDI, then use TDI_ARCH_TYPE_UNKNOWN
+ */
 enum tdi_arch_type_e {
   TDI_ARCH_TYPE_BEGIN = 0,
   TDI_ARCH_TYPE_PSA,
@@ -117,7 +117,6 @@ enum tdi_arch_type_e {
   TDI_ARCH_TYPE_TNA,
   TDI_ARCH_TYPE_UNKNOWN,
 };
-
 
 /**
  * @brief Mgr type. Devices need to
@@ -128,8 +127,8 @@ typedef enum {
 } tdi_mgr_type_e;
 
 /**
-* @brief Target top level enum and reservation
-*/
+ * @brief Target top level enum and reservation
+ */
 enum tdi_target_e {
   TDI_TARGET_CORE = 0,
   TDI_TARGET_ARCH = 0x08,
@@ -137,28 +136,32 @@ enum tdi_target_e {
 };
 
 /**
-* @brief Flags top level enum and reservation
-*/
+ * @brief Flags top level enum and reservation
+ * This enum denotes the index in a 64 bit flag.
+ * So the first 8(0-7) bits are reserved for core.
+ * 8-15 are for arch. 16-63 are for device.
+ */
 enum tdi_flags_e {
   TDI_FLAGS_CORE = 0,
   TDI_FLAGS_ARCH = 0x08,
-  TDI_FLAGS_DEVICE = 0x80,
+  TDI_FLAGS_DEVICE = 0x10,
+  TDI_FLAGS_END = 0x40,
 };
 
 /**
-* @brief Table type top level enum and reservation.
-* Taking larger reservation space than other enums due
-* to possibility of high number of table types
-*/
+ * @brief Table type top level enum and reservation.
+ * Taking larger reservation space than other enums due
+ * to possibility of high number of table types
+ */
 enum tdi_table_type_e {
-  TDI_TABLE_TYPE_CORE   = 0x0000,
-  TDI_TABLE_TYPE_ARCH   = 0x0080,
+  TDI_TABLE_TYPE_CORE = 0x0000,
+  TDI_TABLE_TYPE_ARCH = 0x0080,
   TDI_TABLE_TYPE_DEVICE = 0x0800,
 };
 
 /**
-* @brief Match type top level enum and reservation
-*/
+ * @brief Match type top level enum and reservation
+ */
 enum tdi_match_type_e {
   TDI_MATCH_TYPE_CORE = 0,
   TDI_MATCH_TYPE_ARCH = 0x08,
@@ -166,8 +169,8 @@ enum tdi_match_type_e {
 };
 
 /**
-* @brief Attributes top level enum and reservation
-*/
+ * @brief Attributes top level enum and reservation
+ */
 enum tdi_attributes_type_e {
   TDI_ATTRIBUTES_TYPE_CORE = 0,
   TDI_ATTRIBUTES_TYPE_ARCH = 0x08,
@@ -175,19 +178,18 @@ enum tdi_attributes_type_e {
 };
 
 /**
-* @brief Attribute field enums. Either of
-* core, arch or target will define entire list and
-* hence doesn't need to be split.
-*
-*/
+ * @brief Attribute field enums. Either of
+ * core, arch or target will define entire list and
+ * hence doesn't need to be split.
+ *
+ */
 enum tdi_attributes_field_type_e {
   TDI_ATTRIBUTES_FIELD_BEGIN = 0,
 };
- 
 
 /**
-* @brief Operations top level enum and reservation
-*/
+ * @brief Operations top level enum and reservation
+ */
 enum tdi_operations_type_e {
   TDI_OPERATIONS_TYPE_CORE = 0,
   TDI_OPERATIONS_TYPE_ARCH = 0x08,
@@ -195,47 +197,47 @@ enum tdi_operations_type_e {
 };
 
 /**
-* @brief Operations field enums. Either of
-* core, arch or target will define entire list and
-* hence doesn't need to be split.
-*
-*/
+ * @brief Operations field enums. Either of
+ * core, arch or target will define entire list and
+ * hence doesn't need to be split.
+ *
+ */
 enum tdi_operations_field_type_e {
   TDI_OPERATIONS_FIELD_BEGIN = 0,
 };
- 
 
 /** Identifies an error code. */
 typedef int tdi_status_t;
 
 #define TDI_STATUS_VALUES                                                    \
-  TDI_STATUS_(TDI_SUCCESS, "Success"), TDI_STATUS_(TDI_NOT_READY, "Not ready"), \
-      TDI_STATUS_(TDI_NO_SYS_RESOURCES, "No system resources"),               \
-      TDI_STATUS_(TDI_INVALID_ARG, "Invalid arguments"),                      \
-      TDI_STATUS_(TDI_ALREADY_EXISTS, "Already exists"),                      \
-      TDI_STATUS_(TDI_HW_COMM_FAIL, "HW access fails"),                       \
-      TDI_STATUS_(TDI_OBJECT_NOT_FOUND, "Object not found"),                  \
-      TDI_STATUS_(TDI_MAX_SESSIONS_EXCEEDED, "Max sessions exceeded"),        \
-      TDI_STATUS_(TDI_SESSION_NOT_FOUND, "Session not found"),                \
-      TDI_STATUS_(TDI_NO_SPACE, "Not enough space"),                          \
-      TDI_STATUS_(TDI_EAGAIN,                                                 \
-                 "Resource temporarily not available, try again later"),    \
-      TDI_STATUS_(TDI_INIT_ERROR, "Initialization error"),                    \
-      TDI_STATUS_(TDI_TXN_NOT_SUPPORTED, "Not supported in transaction"),     \
-      TDI_STATUS_(TDI_TABLE_LOCKED, "Resource held by another session"),      \
-      TDI_STATUS_(TDI_IO, "IO error"),                                        \
-      TDI_STATUS_(TDI_UNEXPECTED, "Unexpected error"),                        \
-      TDI_STATUS_(TDI_ENTRY_REFERENCES_EXIST,                                 \
-                 "Action data entry is being referenced by match entries"), \
-      TDI_STATUS_(TDI_NOT_SUPPORTED, "Operation not supported"),              \
-      TDI_STATUS_(TDI_HW_UPDATE_FAILED, "Updating hardware failed"),          \
-      TDI_STATUS_(TDI_NO_LEARN_CLIENTS, "No learning clients registered"),    \
-      TDI_STATUS_(TDI_IDLE_UPDATE_IN_PROGRESS,                                \
-                 "Idle time update state already in progress"),             \
-      TDI_STATUS_(TDI_DEVICE_LOCKED, "Device locked"),                        \
-      TDI_STATUS_(TDI_INTERNAL_ERROR, "Internal error"),                      \
-      TDI_STATUS_(TDI_TABLE_NOT_FOUND, "Table not found"),                    \
-      TDI_STATUS_(TDI_IN_USE, "In use"),                                      \
+  TDI_STATUS_(TDI_SUCCESS, "Success"),                                       \
+      TDI_STATUS_(TDI_NOT_READY, "Not ready"),                               \
+      TDI_STATUS_(TDI_NO_SYS_RESOURCES, "No system resources"),              \
+      TDI_STATUS_(TDI_INVALID_ARG, "Invalid arguments"),                     \
+      TDI_STATUS_(TDI_ALREADY_EXISTS, "Already exists"),                     \
+      TDI_STATUS_(TDI_HW_COMM_FAIL, "HW access fails"),                      \
+      TDI_STATUS_(TDI_OBJECT_NOT_FOUND, "Object not found"),                 \
+      TDI_STATUS_(TDI_MAX_SESSIONS_EXCEEDED, "Max sessions exceeded"),       \
+      TDI_STATUS_(TDI_SESSION_NOT_FOUND, "Session not found"),               \
+      TDI_STATUS_(TDI_NO_SPACE, "Not enough space"),                         \
+      TDI_STATUS_(TDI_EAGAIN,                                                \
+                  "Resource temporarily not available, try again later"),    \
+      TDI_STATUS_(TDI_INIT_ERROR, "Initialization error"),                   \
+      TDI_STATUS_(TDI_TXN_NOT_SUPPORTED, "Not supported in transaction"),    \
+      TDI_STATUS_(TDI_TABLE_LOCKED, "Resource held by another session"),     \
+      TDI_STATUS_(TDI_IO, "IO error"),                                       \
+      TDI_STATUS_(TDI_UNEXPECTED, "Unexpected error"),                       \
+      TDI_STATUS_(TDI_ENTRY_REFERENCES_EXIST,                                \
+                  "Action data entry is being referenced by match entries"), \
+      TDI_STATUS_(TDI_NOT_SUPPORTED, "Operation not supported"),             \
+      TDI_STATUS_(TDI_HW_UPDATE_FAILED, "Updating hardware failed"),         \
+      TDI_STATUS_(TDI_NO_LEARN_CLIENTS, "No learning clients registered"),   \
+      TDI_STATUS_(TDI_IDLE_UPDATE_IN_PROGRESS,                               \
+                  "Idle time update state already in progress"),             \
+      TDI_STATUS_(TDI_DEVICE_LOCKED, "Device locked"),                       \
+      TDI_STATUS_(TDI_INTERNAL_ERROR, "Internal error"),                     \
+      TDI_STATUS_(TDI_TABLE_NOT_FOUND, "Table not found"),                   \
+      TDI_STATUS_(TDI_IN_USE, "In use"),                                     \
       TDI_STATUS_(TDI_NOT_IMPLEMENTED, "Object not implemented")
 enum tdi_status_enum {
 #define TDI_STATUS_(x, y) x
@@ -256,7 +258,6 @@ static inline const char *tdi_err_str(tdi_status_t sts) {
   }
 }
 
-
 /**
  * @brief Small helper macro and struct for typedef.
  * For sake of strict typechecking, instead of typedef-ing
@@ -267,7 +268,6 @@ static inline const char *tdi_err_str(tdi_status_t sts) {
     int unused;              \
   };                         \
   typedef struct name##__ name
-
 
 // C frontend typedefs
 DECLARE_HANDLE(tdi_info_hdl);

--- a/include/tdi/common/tdi_table.hpp
+++ b/include/tdi/common/tdi_table.hpp
@@ -650,10 +650,16 @@ class Table {
    */
   virtual bool actionIdApplicable() const { return false; }
 
+  const TdiInfo *tdiInfoGet() const { return tdi_info_; };
+
  protected:
-  Table(const TableInfo *table_info) : table_info_(table_info){};
+  Table(const TdiInfo *tdi_info, const TableInfo *table_info)
+      : tdi_info_(tdi_info), table_info_(table_info){};
 
  private:
+  // Backpinter to the TdiInfo
+  const TdiInfo *tdi_info_;
+  // The TableInfo class containing all the metadata from tdi.json
   const TableInfo *table_info_;
   friend tdi::TdiInfo;
 };  // end of tdi::Table

--- a/include/tdi/common/tdi_table_data.hpp
+++ b/include/tdi/common/tdi_table_data.hpp
@@ -401,13 +401,22 @@ class TableData {
    */
   tdi_status_t isActive(const tdi_id_t &field_id, bool *is_active) const;
 
- private:
+  const bool &allFieldsSetGet() const { return all_fields_set_; };
+  const std::vector<tdi_id_t> &activeFieldsGet() const {
+    return active_fields_;
+  };
+
+ protected:
   // For LearnData, this can be set to nullptr
   const tdi::Table *table_;
+  // For TableData, this can be set to nullptr
+  const tdi::Learn *learn_;
+  bool all_fields_set_{false};
+
+ private:
   tdi_id_t action_id_{0};
   tdi_id_t container_id_{0};
   std::vector<tdi_id_t> active_fields_{};
-  bool all_fields_set_{false};
 };
 
 }  // namespace tdi

--- a/include/tdi/common/tdi_table_data.hpp
+++ b/include/tdi/common/tdi_table_data.hpp
@@ -320,14 +320,12 @@ class TableData {
   /**
    * @brief Get actionId.
    *
-   * @param[out] act_id Pointer to the action id to be filled in. Applicable for
-   *data<br>
-   *             objects associated with tables for which action id is
-   *applicable
-   *
-   * @return Status of the API call
+   * @return Action ID of this data object. If no action
+   * is currently associated or the table doesn't contain
+   * any actions at all, then action ID returned is 0 which
+   * is an invalid Action ID
    */
-  tdi_status_t actionIdGet(tdi_id_t *act_id) const;
+  const tdi_id_t &actionIdGet() const { return action_id_; };
 
   /**
    * @brief Data Allocate for a container field ID. Container ID

--- a/include/tdi/common/tdi_table_key.hpp
+++ b/include/tdi/common/tdi_table_key.hpp
@@ -157,7 +157,7 @@ class TableKey {
    */
   virtual tdi_status_t reset();
 
- private:
+ protected:
   const Table *table_ = nullptr;
 };
 

--- a/include/tdi/common/tdi_table_key.hpp
+++ b/include/tdi/common/tdi_table_key.hpp
@@ -44,32 +44,41 @@ enum tdi_match_type_core_e {
   TDI_MATCH_TYPE_LPM,
 };
 
-
 class KeyFieldValue {
-  public:
+ public:
   virtual ~KeyFieldValue() = default;
+
+ protected:
+  KeyFieldValue(tdi_match_type_e match_type) : match_type_(match_type){};
+
+ private:
+  tdi_match_type_e match_type_;
 };
 
-template<class T>
+template <class T>
 class KeyFieldValueExact : public KeyFieldValue {
  public:
-  KeyFieldValueExact(T &value) : value_(value){};
+  KeyFieldValueExact(T &value)
+      : KeyFieldValue(TDI_MATCH_TYPE_EXACT), value_(value){};
   KeyFieldValueExact(uint8_t *value_ptr, size_t &size)
-      : value_ptr_(value_ptr), size_(size){};
+      : KeyFieldValue(TDI_MATCH_TYPE_EXACT),
+        value_ptr_(value_ptr),
+        size_(size){};
   T value_ = 0;
   uint8_t *value_ptr_ = nullptr;
   size_t size_ = 0;
 };
 
-template<class T>
+template <class T>
 class KeyFieldValueTernary : public KeyFieldValue {
  public:
   KeyFieldValueTernary(T &value, T &mask)
-      : value_(value), mask_(mask){};
-  KeyFieldValueTernary(uint8_t *value_ptr,
-                       uint8_t *mask_ptr,
-                       size_t &size)
-      : value_ptr_(value_ptr), mask_ptr_(mask_ptr), size_(size){};
+      : KeyFieldValue(TDI_MATCH_TYPE_TERNARY), value_(value), mask_(mask){};
+  KeyFieldValueTernary(uint8_t *value_ptr, uint8_t *mask_ptr, size_t &size)
+      : KeyFieldValue(TDI_MATCH_TYPE_TERNARY),
+        value_ptr_(value_ptr),
+        mask_ptr_(mask_ptr),
+        size_(size){};
   T value_ = 0;
   uint8_t *value_ptr_ = nullptr;
   T mask_ = 0;
@@ -77,13 +86,18 @@ class KeyFieldValueTernary : public KeyFieldValue {
   size_t size_ = 0;
 };
 
-template<class T>
+template <class T>
 class KeyFieldValueLPM : public KeyFieldValue {
  public:
   KeyFieldValueLPM(T &value, uint16_t &prefix_len)
-      : value_(value), prefix_len_(prefix_len) {};
+      : KeyFieldValue(TDI_MATCH_TYPE_LPM),
+        value_(value),
+        prefix_len_(prefix_len){};
   KeyFieldValueLPM(uint8_t *value_ptr, uint16_t &prefix_len, size_t &size)
-      : value_ptr_(value_ptr), prefix_len_(prefix_len), size_(size) {};
+      : KeyFieldValue(TDI_MATCH_TYPE_LPM),
+        value_ptr_(value_ptr),
+        prefix_len_(prefix_len),
+        size_(size){};
   T value_ = 0;
   uint8_t *value_ptr_ = nullptr;
   uint16_t prefix_len_ = 0;
@@ -111,10 +125,10 @@ class TableKey {
    * @return Status of the API call
    */
   virtual tdi_status_t setValue(const tdi_id_t &field_id,
-                               const tdi::KeyFieldValue &&field_value);
+                                const tdi::KeyFieldValue &&field_value);
 
   virtual tdi_status_t setValue(const tdi_id_t &field_id,
-                               const tdi::KeyFieldValue &field_value);
+                                const tdi::KeyFieldValue &field_value);
 
   /**
    * @brief Get value. Only valid on fields of \ref tdi::KeyFieldType "EXACT"
@@ -126,7 +140,6 @@ class TableKey {
    */
   virtual tdi_status_t getValue(const tdi_id_t &field_id,
                                 tdi::KeyFieldValue *value) const;
-
 
   /**
    * @brief Get the Table Object associated with this Key Object
@@ -140,13 +153,14 @@ class TableKey {
   /**
    * @brief Reset the TableKey object
    *
-   * @return 
+   * @return
    */
   virtual tdi_status_t reset();
+
  private:
   const Table *table_ = nullptr;
 };
 
-}  // tdi
+}  // namespace tdi
 
 #endif  // _TDI_TABLE_KEY_HPP

--- a/include/tdi/common/tdi_target.hpp
+++ b/include/tdi/common/tdi_target.hpp
@@ -81,29 +81,28 @@ class Target {
   virtual ~Target() = default;
   virtual tdi_status_t setValue(const tdi_target_e &target,
                                 const uint32_t &value);
-  virtual tdi_status_t getValue(const tdi_target_e &target, uint32_t *value);
+  virtual tdi_status_t getValue(const tdi_target_e &target,
+                                uint32_t *value) const;
 
  protected:
   Target(const tdi_dev_id_t &dev_id) : dev_id_(dev_id){};
-
- private:
-  friend class tdi::Device;
   tdi_dev_id_t dev_id_;
+
+  friend class tdi::Device;
 };
 
 /**
- * @brief Can be constructed by \ref tdi::Device::createFlags()
+ * @brief Simple wrapper over a uin64_t flags. Each bit is controlled by
+ * tdi_flags_e values.
+ * Can be constructed by \ref tdi::Device::createFlags()
  */
 class Flags {
  public:
+  Flags(const uint64_t &flags) : flags_(flags){};
   virtual ~Flags() = default;
   tdi_status_t setValue(const tdi_flags_e &flags, const bool &val);
-  tdi_status_t getValue(const tdi_flags_e &flags, bool *val);
+  tdi_status_t getValue(const tdi_flags_e &flags, bool *val) const;
   const uint64_t &getFlags() { return flags_; };
-
- private:
-  friend class Device;
-  Flags(const uint64_t &flags) : flags_(flags){};
   uint64_t flags_ = 0;
 };
 

--- a/src/arch/tna/tna_target.cpp
+++ b/src/arch/tna/tna_target.cpp
@@ -20,16 +20,18 @@
 // arch include
 #include <tdi/arch/tna/tna_target.hpp>
 
-//local includes
+// local includes
 #include <tdi/common/tdi_utils.hpp>
 
 namespace tdi {
 namespace tna {
 
-tdi_status_t Target::setValue(const tdi_target_e &target_field, const uint32_t &value) {
-  if (target_field == static_cast<tdi_target_e>(TNA_TARGET_PIPE_ID)) {
+tdi_status_t Target::setValue(const tdi_target_e &target_field,
+                              const uint32_t &value) {
+  if (target_field == static_cast<tdi_target_e>(TDI_TNA_TARGET_PIPE_ID)) {
     this->pipe_id_ = value;
-  } else if (target_field == static_cast<tdi_target_e>(TNA_TARGET_DIRECTION)) {
+  } else if (target_field ==
+             static_cast<tdi_target_e>(TDI_TNA_TARGET_DIRECTION)) {
     this->direction_ = static_cast<tna_direction_e>(value);
   } else {
     return tdi::Target::setValue(target_field, value);
@@ -37,10 +39,12 @@ tdi_status_t Target::setValue(const tdi_target_e &target_field, const uint32_t &
   return TDI_SUCCESS;
 }
 
-tdi_status_t Target::getValue(const tdi_target_e &target_field, uint32_t *value) {
-  if (target_field == static_cast<tdi_target_e>(TNA_TARGET_PIPE_ID)) {
+tdi_status_t Target::getValue(const tdi_target_e &target_field,
+                              uint32_t *value) const {
+  if (target_field == static_cast<tdi_target_e>(TDI_TNA_TARGET_PIPE_ID)) {
     *value = this->pipe_id_;
-  } else if (target_field == static_cast<tdi_target_e>(TNA_TARGET_DIRECTION)) {
+  } else if (target_field ==
+             static_cast<tdi_target_e>(TDI_TNA_TARGET_DIRECTION)) {
     *value = static_cast<uint32_t>(this->direction_);
   } else {
     return tdi::Target::getValue(target_field, value);
@@ -48,6 +52,5 @@ tdi_status_t Target::getValue(const tdi_target_e &target_field, uint32_t *value)
   return TDI_SUCCESS;
 }
 
-
-} // tna
-}  // tdi
+}  // namespace tna
+}  // namespace tdi

--- a/src/targets/dummy/tdi_dummy_info.hpp
+++ b/src/targets/dummy/tdi_dummy_info.hpp
@@ -73,6 +73,7 @@ class TdiInfoMapper : public tdi::tna::TdiInfoMapper {
 class TableFactory : public tdi::tna::TableFactory {
  public:
   virtual std::unique_ptr<tdi::Table> makeTable(
+      const TdiInfo *tdi_info,
       const tdi::TableInfo *table_info) const override {
     if (!table_info) {
       LOG_ERROR("%s:%d No table info received", __func__, __LINE__);
@@ -82,22 +83,28 @@ class TableFactory : public tdi::tna::TableFactory {
         static_cast<tdi_dummy_table_type_e>(table_info->tableTypeGet());
     switch (table_type) {
       case TDI_DUMMY_TABLE_TYPE_MATCH_DIRECT:
-        return std::unique_ptr<tdi::Table>(new MatchActionDirect(table_info));
+        return std::unique_ptr<tdi::Table>(
+            new MatchActionDirect(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_MATCH_INDIRECT:
       case TDI_DUMMY_TABLE_TYPE_MATCH_INDIRECT_SELECTOR:
-        return std::unique_ptr<tdi::Table>(new MatchActionIndirect(table_info));
+        return std::unique_ptr<tdi::Table>(
+            new MatchActionIndirect(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_ACTION_PROFILE:
-        return std::unique_ptr<tdi::Table>(new ActionProfile(table_info));
+        return std::unique_ptr<tdi::Table>(
+            new ActionProfile(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_SELECTOR:
-        return std::unique_ptr<tdi::Table>(new Selector(table_info));
+        return std::unique_ptr<tdi::Table>(new Selector(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_COUNTER:
-        return std::unique_ptr<tdi::Table>(new CounterIndirect(table_info));
+        return std::unique_ptr<tdi::Table>(
+            new CounterIndirect(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_METER:
-        return std::unique_ptr<tdi::Table>(new MeterIndirect(table_info));
+        return std::unique_ptr<tdi::Table>(
+            new MeterIndirect(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_PORT_CFG:
-        return std::unique_ptr<tdi::Table>(new PortConfigure(table_info));
+        return std::unique_ptr<tdi::Table>(
+            new PortConfigure(tdi_info, table_info));
       case TDI_DUMMY_TABLE_TYPE_PORT_STAT:
-        return std::unique_ptr<tdi::Table>(new PortStat(table_info));
+        return std::unique_ptr<tdi::Table>(new PortStat(tdi_info, table_info));
       default:
         return nullptr;
     }

--- a/src/targets/dummy/tdi_dummy_init.cpp
+++ b/src/targets/dummy/tdi_dummy_init.cpp
@@ -47,7 +47,8 @@ Device::Device(const tdi_dev_id_t &device_id,
     auto tdi_info_parser = std::unique_ptr<TdiInfoParser>(
         new TdiInfoParser(std::move(tdi_info_mapper)));
     tdi_info_parser->parseTdiInfo(program_config.tdi_info_file_paths_);
-    auto tdi_info = tdi::TdiInfo::makeTdiInfo(std::move(tdi_info_parser),
+    auto tdi_info = tdi::TdiInfo::makeTdiInfo(program_config.prog_name_,
+                                              std::move(tdi_info_parser),
                                               table_factory.get());
     tdi_info_map_[program_config.prog_name_] = std::move(tdi_info);
   }

--- a/src/targets/dummy/tdi_dummy_table.hpp
+++ b/src/targets/dummy/tdi_dummy_table.hpp
@@ -32,7 +32,9 @@ namespace dummy {
 
 class MatchActionDirect : public tdi::Table {
  public:
-  MatchActionDirect(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  MatchActionDirect(const tdi::TdiInfo *tdi_info,
+                    const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 
@@ -41,57 +43,67 @@ class MatchActionDirect : public tdi::Table {
 
 class MatchActionIndirect : public tdi::Table {
  public:
-  MatchActionIndirect(const tdi::TableInfo *table_info)
-      : tdi::Table(table_info) {
+  MatchActionIndirect(const tdi::TdiInfo *tdi_info,
+                      const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class ActionProfile : public tdi::Table {
  public:
-  ActionProfile(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  ActionProfile(const tdi::TdiInfo *tdi_info, const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class Selector : public tdi::Table {
  public:
-  Selector(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  Selector(const tdi::TdiInfo *tdi_info, const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class CounterIndirect : public tdi::Table {
  public:
-  CounterIndirect(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  CounterIndirect(const tdi::TdiInfo *tdi_info,
+                  const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class MeterIndirect : public tdi::Table {
  public:
-  MeterIndirect(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  MeterIndirect(const tdi::TdiInfo *tdi_info, const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class RegisterIndirect : public tdi::Table {
  public:
-  RegisterIndirect(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  RegisterIndirect(const tdi::TdiInfo *tdi_info,
+                   const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class PortConfigure : public tdi::Table {
  public:
-  PortConfigure(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  PortConfigure(const tdi::TdiInfo *tdi_info, const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };
 
 class PortStat : public tdi::Table {
  public:
-  PortStat(const tdi::TableInfo *table_info) : tdi::Table(table_info) {
+  PortStat(const tdi::TdiInfo *tdi_info, const tdi::TableInfo *table_info)
+      : tdi::Table(tdi_info, table_info) {
     LOG_ERROR("Creating table for %s", table_info->nameGet().c_str());
   };
 };

--- a/src/tdi_info.cpp
+++ b/src/tdi_info.cpp
@@ -117,11 +117,12 @@ void populateFullNameMap(
 }  // anonymous namespace
 
 std::unique_ptr<const TdiInfo> TdiInfo::makeTdiInfo(
+    const std::string &p4_name,
     std::unique_ptr<TdiInfoParser> tdi_info_parser,
     const tdi::TableFactory *factory) {
   try {
     std::unique_ptr<const TdiInfo> tdi_info(
-        new TdiInfo(std::move(tdi_info_parser), factory));
+        new TdiInfo(p4_name, std::move(tdi_info_parser), factory));
     return tdi_info;
   } catch (...) {
     LOG_ERROR("%s:%d Failed to create TdiInfo", __func__, __LINE__);
@@ -129,9 +130,10 @@ std::unique_ptr<const TdiInfo> TdiInfo::makeTdiInfo(
   }
 }
 
-TdiInfo::TdiInfo(std::unique_ptr<TdiInfoParser> tdi_info_parser,
+TdiInfo::TdiInfo(const std::string &p4_name,
+                 std::unique_ptr<TdiInfoParser> tdi_info_parser,
                  const tdi::TableFactory *factory)
-    : tdi_info_parser_(std::move(tdi_info_parser)) {
+    : p4_name_(p4_name), tdi_info_parser_(std::move(tdi_info_parser)) {
   // Go over all table_info and learn_info in the parser object and
   // create Table and Learn objects for them
   for (const auto &kv : tdi_info_parser_->tableInfoMapGet()) {
@@ -141,7 +143,7 @@ TdiInfo::TdiInfo(std::unique_ptr<TdiInfoParser> tdi_info_parser,
                 __LINE__,
                 kv.first.c_str());
     } else {
-      auto table = factory->makeTable(kv.second.get());
+      auto table = factory->makeTable(this, kv.second.get());
       if (!table) {
         LOG_ERROR("%s:%d Error creating Table:%s",
                   __func__,

--- a/src/tdi_json_parser/tdi_table_info.cpp
+++ b/src/tdi_json_parser/tdi_table_info.cpp
@@ -176,6 +176,15 @@ const ActionInfo *TableInfo::actionGet(const tdi_id_t &action_id) const {
   return nullptr;
 }
 
+std::vector<tdi_id_t> TableInfo::actionIdListGet() const {
+  std::vector<tdi_id_t> id_vec;
+  for (const auto &kv : table_action_map_) {
+    id_vec.push_back(kv.first);
+  }
+  std::sort(id_vec.begin(), id_vec.end());
+  return id_vec;
+}
+
 #if 0
 tdi_status_t Table::getDataField(const tdi_id_t &field_id,
                                  const TableDataField **field) const {

--- a/src/tdi_json_parser/tests/tdi_info_test.hpp
+++ b/src/tdi_json_parser/tests/tdi_info_test.hpp
@@ -88,8 +88,10 @@ void setupInternal(T *obj) {
   ASSERT_EQ(status, TDI_SUCCESS)
       << "Failed to parse file : " << program_config.tdi_info_file_paths_[0];
 
-  obj->tdi_info = std::move(tdi::TdiInfo::makeTdiInfo(
-      std::move(tdi_info_parser), table_factory.get()));
+  obj->tdi_info =
+      std::move(tdi::TdiInfo::makeTdiInfo(program_config.prog_name_,
+                                          std::move(tdi_info_parser),
+                                          table_factory.get()));
 
   ASSERT_NE(obj->tdi_info, nullptr) << "Failed to open json files";
 }

--- a/src/tdi_table_data.cpp
+++ b/src/tdi_table_data.cpp
@@ -134,11 +134,6 @@ tdi_status_t TableData::getValue(const tdi_id_t & /*field_id*/,
   return TDI_NOT_SUPPORTED;
 }
 
-tdi_status_t TableData::actionIdGet(tdi_id_t *act_id) const {
-  *act_id = this->action_id_;
-  return TDI_SUCCESS;
-}
-
 tdi_status_t TableData::dataAllocate(
     const tdi_id_t & /*container_id*/,
     std::unique_ptr<tdi::TableData> * /*data_ret*/) const {

--- a/src/tdi_target.cpp
+++ b/src/tdi_target.cpp
@@ -17,12 +17,13 @@
 #include <tdi/common/tdi_info.hpp>
 #include <tdi/common/tdi_init.hpp>
 
-//local includes
+// local includes
 #include <tdi/common/tdi_utils.hpp>
 
 namespace tdi {
 
-tdi_status_t Target::setValue(const tdi_target_e &target_e, const uint32_t &value) {
+tdi_status_t Target::setValue(const tdi_target_e &target_e,
+                              const uint32_t &value) {
   if (target_e == static_cast<tdi_target_e>(TDI_TARGET_DEV_ID)) {
     this->dev_id_ = value;
   } else {
@@ -31,7 +32,8 @@ tdi_status_t Target::setValue(const tdi_target_e &target_e, const uint32_t &valu
   return TDI_SUCCESS;
 }
 
-tdi_status_t Target::getValue(const tdi_target_e &target_e, uint32_t *value) {
+tdi_status_t Target::getValue(const tdi_target_e &target_e,
+                              uint32_t *value) const {
   if (target_e == static_cast<tdi_target_e>(TDI_TARGET_DEV_ID)) {
     *value = this->dev_id_;
   } else {
@@ -48,10 +50,9 @@ tdi_status_t Flags::setValue(const tdi_flags_e &flags_e, const bool &val) {
   return TDI_SUCCESS;
 }
 
-tdi_status_t Flags::getValue(const tdi_flags_e &flags_e, bool *value) {
+tdi_status_t Flags::getValue(const tdi_flags_e &flags_e, bool *value) const {
   *value = (this->flags_ & (1ull << flags_e));
   return TDI_SUCCESS;
 }
 
-
-}  // tdi
+}  // namespace tdi


### PR DESCRIPTION
* Correcting match_type enum names to match convention to tdi_tna_match_type_e
* Adding tdi_tna_target_e
* Adding const to Target::getValue
* Correcting tdi_flags_e enum to correctly represent the 64 bit value
* Adding p4_name to TdiInfo class, description and API to retrieve
* Adding backpointer to TdiInfo in Table class
* converting TableData:actionIdGet() to return const ref to actionId itself rather than return status and take in param
* making table_, learn_, and all_fields_set_ in TableData to be protected so that derived classes can have access and change them freely. Future change = add correct reset and default initialize functions so that only one entry point to change these internal member variables during init time or reset time
* Adding match_type information in KeyFieldValue so that TableKey setValue can know the object type during runtime without dynamic_cast
* Converting tdi::Flags to a purely public class. Any device can directly call Flags(uint64_t) and create a Flag object to keep it simple. Device::createFlags() won't be needed and will be removed.
* Adding temp actionIdListGet() function. Future imrovement would be to remove any kind of vector copying and just store required vectors in memory and return const refs.