### PR TITLE
ATCAM match type treated as EXACT match

### DIFF
--- a/include/tdi/arch/tna/tna_info.hpp
+++ b/include/tdi/arch/tna/tna_info.hpp
@@ -52,8 +52,9 @@ class TdiInfoMapper : public tdi::TdiInfoMapper {
  public:
   TdiInfoMapper() {
     // Match types
+    // ATCAM match type treated as exact match
     matchEnumMapAdd(tdi_json::values::tna::TABLE_KEY_MATCH_TYPE_ATCAM,
-                    static_cast<tdi_match_type_e>(TDI_TNA_MATCH_TYPE_ATCAM));
+                    static_cast<tdi_match_type_e>(TDI_MATCH_TYPE_EXACT));
   }
 };
 


### PR DESCRIPTION
**Testing:**
tdi.tna_ternary_match.pipe.SwitchIngress.forward_atcam> add_with_hit(dst_addr="1.1.1.1", dst_addr_mask="255.255.255.255")
table_type=0x800
table_type=0x800
table_type=0x800
