### PR TITLE
Make corresponding target field mapping based on the latest python CLI.

### DIFF
--- a/include/tdi/arch/pna/pna_target.hpp
+++ b/include/tdi/arch/pna/pna_target.hpp
@@ -37,9 +37,8 @@ namespace pna {
 class Device;
 
 enum pna_target_e {
-  PNA_TARGET_PIPE_ID = TDI_TARGET_ARCH,
-  PNA_TARGET_DIRECTION,
-  PNA_TARGET_DEV_ID,
+  PNA_TARGET_PIPE_ID = TDI_TARGET_ARCH+0,
+  PNA_TARGET_DIRECTION = TDI_TARGET_ARCH+1,
 };
 
 /**

--- a/include/tdi/common/tdi_defs.h
+++ b/include/tdi/common/tdi_defs.h
@@ -140,6 +140,13 @@ enum tdi_target_e {
 };
 
 /**
+* @brief Target core top level enum and reservation
+*/
+enum tdi_target_core_enum_e {
+  TDI_TARGET_DEV_ID = TDI_TARGET_CORE,
+};
+
+/**
  * @brief Flags top level enum and reservation
  * This enum denotes the index in a 64 bit flag.
  * So the first 8(0-7) bits are reserved for core.

--- a/include/tdi/common/tdi_target.hpp
+++ b/include/tdi/common/tdi_target.hpp
@@ -70,9 +70,6 @@ class ProgramConfig {
   const std::vector<tdi::P4Pipeline> p4_pipelines_;
 };
 
-enum tdi_target_core_enum_e {
-  TDI_TARGET_DEV_ID = TDI_TARGET_CORE,
-};
 /**
  * @brief Can be constructed by \ref tdi::Device::createTarget()
  */

--- a/src/tdi_target.cpp
+++ b/src/tdi_target.cpp
@@ -16,6 +16,7 @@
 // tdi includes
 #include <tdi/common/tdi_info.hpp>
 #include <tdi/common/tdi_init.hpp>
+#include <tdi/common/tdi_defs.h>
 
 // local includes
 #include <tdi/common/tdi_utils.hpp>


### PR DESCRIPTION
1. remove the DEV_ID from pna - since parent (core target implement
   this).
2. change the field type id according to python CLI mapping.