### PR TITLE
IPDKDRV-119 Fix for memory leak

### DIFF
--- a/src/c_frontend/tdi_init_c.cpp
+++ b/src/c_frontend/tdi_init_c.cpp
@@ -34,16 +34,12 @@ tdi_status_t tdi_device_get(const tdi_dev_id_t dev_id,
 
 tdi_status_t tdi_flags_create(const uint64_t flag_value,
                               const tdi_flags_hdl **flags) {
-  tdi_status_t sts = TDI_SUCCESS;
+  if (flags == nullptr) {
+    LOG_ERROR("%s:%d null param passed", __func__, __LINE__);
+    return TDI_INVALID_ARG;
+  }
   tdi::Flags *flgs = new tdi::Flags(flag_value);
   *flags = reinterpret_cast<const tdi_flags_hdl *>(flgs);
-  if (sts != TDI_SUCCESS) {
-    return sts;
-  }
-  if (flags == nullptr) {
-    LOG_ERROR("%s:%d Unable to create flags", __func__, __LINE__);
-    return TDI_UNEXPECTED;
-  }
   return TDI_SUCCESS;
 }
 

--- a/src/c_frontend/tdi_table_data_c.cpp
+++ b/src/c_frontend/tdi_table_data_c.cpp
@@ -77,11 +77,13 @@ tdi_status_t tdi_data_field_set_value_str_array(tdi_table_data_hdl *data_hdl,
                                                  const char *val) {
   auto data_field = reinterpret_cast<tdi::TableData *>(data_hdl);
   std::vector<std::string> vec;
-  char *token = strtok(strdup(val), " ");
+  char *val_dup = strdup(val);
+  char *token = strtok(val_dup, " ");
   while (token != NULL) {
     vec.push_back(std::string(token));
     token = strtok(NULL, " ");
   }
+  delete val_dup;
   return data_field->setValue(field_id, vec);
 }
 


### PR DESCRIPTION
#717 ipdk-tdi klocwork issue.

Dynamic memory stored in 'strdup(val)' allocated through function 'strdup' is deleted after use.