### PR TITLE
fix for add_from_json with register data fields

### DIFF
--- a/tdi_python/tdicli.py
+++ b/tdi_python/tdicli.py
@@ -949,7 +949,17 @@ class TDILeaf(TDIContext):
                     for k, v in skey.items():
                         key[k.encode('ascii')] = v
                     for k, v in sdata.items():
-                        data[k.encode('ascii')] = v
+                        ''' In dump output, the Register datafield is in the form of list of 4 elements, one per pipe.
+                            But the Register datafield is BYTE_STREAM
+                            so picking the first element of the list as input for Register datafield.
+                        '''
+                        if type(v) is list:
+                            data_field = self._c_tbl.actions[action]["data_fields"][k.encode('ascii')]
+                            data_type = self._c_tbl.data_type_map(data_field.data_type)
+                            if data_type in ["UINT64", "BYTE_STREAM", "BOOL"] and ('$bfrt_field_class', 'register_data') in data_field.annotations:
+                                data[k.encode('ascii')] = v[0]
+                        else:
+                            data[k.encode('ascii')] = v
                     parsed_keys, parsed_data = self._c_tbl.parse_str_input("add_from_json", key, data, action)
                     if parsed_keys == -1:
                         return


### PR DESCRIPTION
**Root cause:**
dump command outputs the register data fields as a list. So dump to json files has register datafield as list. But register data field is BYTE_STREAM and expects the input as BYTE_STREAM while adding entries.

**Resolution:**
Picking the first element of the list as input for Register datafield.

**Testing:**
tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> add_with_change_dmac(dst_addr="1.1.1.1", dst_addr_mask="255.255.255.255", src_addr="2.2.2.2",src_addr_mask="255.255.255.255", MATCH_PRIORITY=1, dstMac=0x0a0b0c0d0e0f, dst_port=5, fir
                                                ...: st="1", second="2")

tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> a=dump(json=True)
table_type=0x800
----- tcam_table Dump Start -----

tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> a
Out[7]: '[{"table_name": "pipe.SwitchIngress.tcam_table", "action": "SwitchIngress.change_dmac", "key": {"hdr.ipv4.dst_addr": [16843009, 4294967295], "hdr.ipv4.src_addr": [33686018, 4294967295], "$MATCH_PRIORITY": 1}, "data": {"dstMac"
: 11042563100175, "dst_port": 5, "SwitchIngress.direct_reg.first": [1, 1, 1, 1], "SwitchIngress.direct_reg.second": [2, 2, 2, 2]}}]'


tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> clear
---------------------------------------------------> clear()

tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> dump
---------------------------------------------------> dump()
table_type=0x800
----- tcam_table Dump Start -----
Default Entry:
table_type=0x800
Entry data (action : NoAction):
    SwitchIngress.direct_reg.first : []
    SwitchIngress.direct_reg.second : []

Table pipe.SwitchIngress.tcam_table has no entries.
----- tcam_table Dump End -----

tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> add_from_json(a)
data_type=BYTE_STREAM
data_type=BYTE_STREAM
data_type=BYTE_STREAM
data_type=BYTE_STREAM

tdi.tna_ternary_match.pipe.SwitchIngress.tcam_table> dump()
table_type=0x800
----- tcam_table Dump Start -----
Default Entry:
table_type=0x800
Entry data (action : NoAction):
    SwitchIngress.direct_reg.first : []
    SwitchIngress.direct_reg.second : []

Entry 0:
Entry key:
    hdr.ipv4.dst_addr              : ('0x01010101', '0xFFFFFFFF')
    hdr.ipv4.src_addr              : ('0x02020202', '0xFFFFFFFF')
    $MATCH_PRIORITY                : 1
Entry data (action : SwitchIngress.change_dmac):
    dstMac                         : 0x0A0B0C0D0E0F
    dst_port                       : 0x05
    SwitchIngress.direct_reg.first : [1, 1, 1, 1]
    SwitchIngress.direct_reg.second : [2, 2, 2, 2]

----- tcam_table Dump End -----
