### PR TITLE
Removed set_default action for tables with const default action

### DIFF
--- a/tdi_python/tdicli.py
+++ b/tdi_python/tdicli.py
@@ -1468,7 +1468,7 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
 
     def _create_set_default(self, data_fields):
         method_name = "set_default"
-        if method_name not in self._c_tbl.supported_commands:
+        if method_name not in self._c_tbl.supported_commands or self._c_tbl.has_const_default_action:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, data_fields=data_fields)


### PR DESCRIPTION
**Testing:**

tdi.tna_action_profile.pipe.SwitchIngress> fib
-----------------------------------------> fib()
TDI Runtime CLI Object for pipe.SwitchIngress.fib table

Key fields:
    vrf                            type=EXACT      size=10
    dst_addr                       type=LPM        size=32


Data fields:
    $ACTION_MEMBER_ID              type=UINT64     size=32


Available Commands:
add
add_from_json
clear
delete
dump
entry
get
get_default
get_handle
get_key
info
mod

