### PR TITLE
Enable port_status_notif_cb on python CLI:

### DIFF
--- a/tdi_python/tdiTable.py
+++ b/tdi_python/tdiTable.py
@@ -2015,11 +2015,13 @@ class TdiTable:
         self._attr_deallocate(attr_hdl)
 
     def _wrap_port_status_notif_cb(self, callback):
-        def callback_wrapper(target, handle, up, cookie):
-            dev_id = target.contents.dev_id
-            entry = self.get_entry(key_content=None, print_entry=False, key_handle=handle)
+        def callback_wrapper(target_hdl, key_hdl, up, cookie):
+            print(self._cintf.print_target(target_hdl))
+            dev_id = c_uint64(0);
+            sts = self._cintf.get_driver().tdi_target_get_value(target_hdl, self._cintf.target_type_map(target_type_str="dev_id"), byref(dev_id));
+            entry = self.get_entry(key_content=None, print_entry=True, key_handle=key_hdl)
             dev_port = list(entry.key.values())[0]
-            callback(dev_id, dev_port, up)
+            callback(dev_id.value, dev_port, up)
             return 0
         return self._cintf.port_status_notif_cb_type(callback_wrapper)
 

--- a/tdi_python/tdicli.py
+++ b/tdi_python/tdicli.py
@@ -174,6 +174,8 @@ class CIntfTdi:
         # why don't need to annotation for self._dev_id to c_int(self._dev_id)
         self._driver.tdi_p4_names_get(self._dev_id, p4_names)
         self.handle_type = POINTER(self.TdiHandle)
+        self.handle_key_type = POINTER(self.TdiHandle)
+        self.handle_target_type = POINTER(self.TdiHandle)
         self.sess_type = POINTER(c_uint)
         self.annotation_type = self.TdiAnnotation
 
@@ -189,7 +191,7 @@ class CIntfTdi:
         self.tdi_tbl_operations_cb_type = CFUNCTYPE(None, POINTER(self.TdiDevTgt), c_void_p)
 
         self.learn_cb_type = CFUNCTYPE(c_int, POINTER(self.TdiDevTgt), self.sess_type, POINTER(self.handle_type), c_uint, self.handle_type, c_void_p)
-        self.port_status_notif_cb_type = CFUNCTYPE(c_int, POINTER(self.TdiDevTgt), self.handle_type, c_bool, c_void_p)
+        self.port_status_notif_cb_type = CFUNCTYPE(c_int, self.handle_target_type, self.handle_key_type, c_bool, c_void_p)
         self.selector_table_update_cb_type = CFUNCTYPE(None, self.sess_type, POINTER(self.TdiDevTgt), c_void_p, c_uint, c_uint, c_int, c_bool)
         self.infos = {}
         for name in p4_names:


### PR DESCRIPTION
1. Fixed python callback function based on TDI Target(change target from structure to target_handle).
2. Fixed callback_wrapper to handle Target handle (based on target_hdl to get dev_id).