### PR TITLE
Refactoring dynamic APIs into target independent and dependent parts

### DIFF
--- a/tdi_python/tdiTable.py
+++ b/tdi_python/tdiTable.py
@@ -32,13 +32,13 @@ class TdiTableError(Exception):
         Exception.__init__(self, str_rep, *args,**kwargs)
 
 class TdiTable:
-
     key_match_type_cls = KeyMatchType
     data_type_cls = DataType
     table_type_cls = TableType
     attributes_type_cls = AttributesType
     operations_type_cls = OperationsType
     flags_type_cls = FlagsType
+    table_entry_cls = TableEntry
 
     """
     This class manages the exchange of information between
@@ -1625,7 +1625,7 @@ class TdiTable:
         return key, entry_tgt
 
     def create_entry_obj(self, key_content, data_content, action=None):
-        entry = TableEntry(self, key_content, data_content, action)
+        entry = self.table_entry_cls(self, key_content, data_content, action)
         return entry
 
     def _allocate_keydata_handles(self):

--- a/tdi_python/tdiTableEntry.py
+++ b/tdi_python/tdiTableEntry.py
@@ -14,48 +14,6 @@
 # limitations under the License.
 #
 import json
-import functools
-
-def target_check_and_set(f):
-    @functools.wraps(f)
-    def target_wrapper(*args, **kw):
-        cintf = args[0]._cintf
-        pipe = None
-        gress_dir = None
-        prsr_id = None
-        old_tgt = None
-
-        for k,v in kw.items():
-            if k == "pipe":
-                pipe = v
-            elif k == "gress_dir":
-                gress_dir = v
-            elif k == "prsr_id":
-                prsr_id = v
-
-        if pipe is not None or gress_dir is not None or prsr_id is not None:
-            old_tgt = cintf._dev_tgt
-        if pipe is not None:
-            cintf._set_pipe(pipe=pipe)
-        if gress_dir is not None:
-            cintf._set_direction(gress_dir)
-        if prsr_id is not None:
-            cintf._set_parser(prsr_id)
-        # If there is an exception, then revert back the
-        # target. Store the ret value of the original function
-        # in case it does return something like some entry_get
-        # functions and return it at the end
-        ret_val = None
-        try:
-            ret_val = f(*args, **kw)
-        except Exception as e:
-            if old_tgt:
-                cintf._dev_tgt = old_tgt
-            raise e
-        if old_tgt:
-            cintf._dev_tgt = old_tgt
-        return ret_val
-    return target_wrapper
 
 class TableEntry:
     def __init__(self, table, key, data, action=None):
@@ -76,8 +34,7 @@ class TableEntry:
     def _get_raw_action(self):
         return self.action
 
-    @target_check_and_set
-    def push(self, verbose=False, pipe=None, gress_dir=None, prsr_id=None):
+    def push(self, verbose=False):
         if verbose:
             print("Checking for entry...")
         if self._c_tbl.get_entry(self.key, print_entry=False) != -1:
@@ -95,8 +52,7 @@ class TableEntry:
             else:
                 self._c_tbl.add_entry(self.key, self.data, self.action)
 
-    @target_check_and_set
-    def update(self, pipe=None, gress_dir=None, prsr_id=None):
+    def update(self):
         entry = self._c_tbl.get_entry(self.key, print_entry=False)
         if isinstance(entry, list):
             if len(entry > 1):
@@ -110,8 +66,7 @@ class TableEntry:
         self.data = entry._get_raw_data()
         self.action = entry._get_raw_action()
 
-    @target_check_and_set
-    def remove(self, pipe=None, gress_dir=None, prsr_id=None):
+    def remove(self):
         self._c_tbl.del_entry(self.key)
 
     def json(self):


### PR DESCRIPTION
**Approach used to bifurcate dynamic APIs into target independent and dependents parts:**

Target derives TDILeaf and overrides dynamic API generation functions(eg: _create_add_with_action). In these functions, code_str is set with the code that is to be used to generate APIs. The target then calls the corresponding parent class function, which creates and adds the dynamic function.