### PR TITLE
tdi_python dynamic API refactoring

### DIFF
--- a/tdi_python/tdiTable.py
+++ b/tdi_python/tdiTable.py
@@ -39,6 +39,7 @@ class TdiTable:
     attributes_type_cls = AttributesType
     operations_type_cls = OperationsType
     flags_type_cls = FlagsType
+    table_entry_cls = TableEntry
 
     """
     This class manages the exchange of information between
@@ -1625,7 +1626,7 @@ class TdiTable:
         return key, entry_tgt
 
     def create_entry_obj(self, key_content, data_content, action=None):
-        entry = TableEntry(self, key_content, data_content, action)
+        entry = self.table_entry_cls(self, key_content, data_content, action)
         return entry
 
     def _allocate_keydata_handles(self):

--- a/tdi_python/tdiTableEntry.py
+++ b/tdi_python/tdiTableEntry.py
@@ -14,48 +14,6 @@
 # limitations under the License.
 #
 import json
-import functools
-
-def target_check_and_set(f):
-    @functools.wraps(f)
-    def target_wrapper(*args, **kw):
-        cintf = args[0]._cintf
-        pipe = None
-        gress_dir = None
-        prsr_id = None
-        old_tgt = None
-
-        for k,v in kw.items():
-            if k == "pipe":
-                pipe = v
-            elif k == "gress_dir":
-                gress_dir = v
-            elif k == "prsr_id":
-                prsr_id = v
-
-        if pipe is not None or gress_dir is not None or prsr_id is not None:
-            old_tgt = cintf._dev_tgt
-        if pipe is not None:
-            cintf._set_pipe(pipe=pipe)
-        if gress_dir is not None:
-            cintf._set_direction(gress_dir)
-        if prsr_id is not None:
-            cintf._set_parser(prsr_id)
-        # If there is an exception, then revert back the
-        # target. Store the ret value of the original function
-        # in case it does return something like some entry_get
-        # functions and return it at the end
-        ret_val = None
-        try:
-            ret_val = f(*args, **kw)
-        except Exception as e:
-            if old_tgt:
-                cintf._dev_tgt = old_tgt
-            raise e
-        if old_tgt:
-            cintf._dev_tgt = old_tgt
-        return ret_val
-    return target_wrapper
 
 class TableEntry:
     def __init__(self, table, key, data, action=None):
@@ -76,8 +34,7 @@ class TableEntry:
     def _get_raw_action(self):
         return self.action
 
-    @target_check_and_set
-    def push(self, verbose=False, pipe=None, gress_dir=None, prsr_id=None):
+    def push(self, verbose=False):
         if verbose:
             print("Checking for entry...")
         if self._c_tbl.get_entry(self.key, print_entry=False) != -1:
@@ -95,8 +52,7 @@ class TableEntry:
             else:
                 self._c_tbl.add_entry(self.key, self.data, self.action)
 
-    @target_check_and_set
-    def update(self, pipe=None, gress_dir=None, prsr_id=None):
+    def update(self):
         entry = self._c_tbl.get_entry(self.key, print_entry=False)
         if isinstance(entry, list):
             if len(entry > 1):
@@ -110,8 +66,7 @@ class TableEntry:
         self.data = entry._get_raw_data()
         self.action = entry._get_raw_action()
 
-    @target_check_and_set
-    def remove(self, pipe=None, gress_dir=None, prsr_id=None):
+    def remove(self):
         self._c_tbl.del_entry(self.key)
 
     def json(self):

--- a/tdi_python/tdicli.py
+++ b/tdi_python/tdicli.py
@@ -35,7 +35,7 @@ import copy
 from tdiTable import TdiTable
 from tdiTable import TdiTableError
 from tdiInfo import TdiInfo
-from tdiTableEntry import TableEntry, target_check_and_set
+from tdiTableEntry import TableEntry
 from tdiDefs import *
 
 from ipaddress import ip_address as ip
@@ -45,7 +45,6 @@ import logging
 _tdi_context = {}
 promp_node = None
 tdi = None
-install_directory = None
 ipython_app = None
 
 class CIntfTdi:
@@ -203,7 +202,7 @@ class CIntfTdi:
         if not sts == 0:
             print("Error, unable to create TDI Runtime session")
             return -1
-        self._dev_tgt = self.TdiDevTgt(self._dev_id, 0, 0xff, 0xff)
+        self._dev_tgt = self.create_devTgt(self._dev_id)
         self.target_type = POINTER(c_uint)
         self._target = self.target_type()
         sts = self._driver.tdi_target_create(self._device, byref(self._target))
@@ -264,13 +263,13 @@ class CIntfTdi:
     class TdiHandle(Structure):
         _fields_ = [("unused", c_int)]
 
-    # class TdiDevTgt(Structure):
-    #     _fields_ = [("dev_id", c_int), ("pipe_id", c_uint), ("direction", c_uint), ("prsr_id", c_ubyte)]
-    #     def __str__(self):
-    #         ret_val = ""
-    #         for name, type_ in self._fields_:
-    #             ret_val += name + ": " + str(getattr(self, name)) + "\n"
-    #         return ret_val
+    class TdiDevTgt(Structure):
+        _fields_ = [("dev_id", c_int)]
+        def __str__(self):
+            ret_val = ""
+            for name, type_ in self._fields_:
+                ret_val += name + ": " + str(getattr(self, name)) + "\n"
+            return ret_val
 
     class TdiTargetHandle(Structure):
         _fields_ = [("unused", c_int)]
@@ -751,8 +750,7 @@ class TDILeaf(TDIContext):
         child._parent_node = self
         exec("self.{} = child".format(child._get_name()))
 
-    @target_check_and_set
-    def info(self, pipe=None, return_info=False, print_info=True):
+    def info(self, return_info=False, print_info=True):
         res = {
             "table_name": self._name,
             "full_name": self._c_tbl.name,
@@ -815,12 +813,10 @@ class TDILeaf(TDIContext):
         if return_info:
             return res
 
-    @target_check_and_set
-    def clear(self, pipe=None, gress_dir=None, prsr_id=None, batch=True):
+    def clear(self, batch=True):
         self._c_tbl.clear(batch)
 
-    @target_check_and_set
-    def dump(self, table=False, pipe=None, gress_dir=None, prsr_id=None, json=False, from_hw=False, return_ents=False, print_zero=True):
+    def dump(self, table=False, json=False, from_hw=False, return_ents=False, print_zero=True):
         """Dump all entries of table including default entry if applicable
         """
         table_type = self._c_tbl.table_type_cls.table_type_str(self._c_tbl.get_type())
@@ -1284,7 +1280,8 @@ Available Commands:
 
         return param_str, param_docstring, parse_key_call, parse_data_call, param_list
 
-    def _create_add_with_action(self, key_fields, data_fields, action_name):
+    # Generating add_with_<action> APIs dynamically
+    def _create_add_with_action(self, key_fields, data_fields, action_name, code_str=None):
         if "add" not in self._c_tbl.supported_commands:
             return
 
@@ -1294,9 +1291,9 @@ Available Commands:
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields, data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {}):
     """Add entry to {} table with action: {}
 
     Parameters:
@@ -1309,20 +1306,23 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
         return
 
     self._c_tbl.add_entry(parsed_keys, parsed_data, b'{}')
-        '''.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
+        '''
+
+        code = code_str.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
         add_method = self._set_dynamic_method(code, method_name)
         self._adds[full_strname] = (add_method, param_list)
 
-    def _create_add(self, key_fields, data_fields):
+    # Generating add APIs dynamically
+    def _create_add(self, key_fields, data_fields, code_str=None):
         method_name = "add"
         if method_name not in self._c_tbl.supported_commands:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields, data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {}):
     """Add entry to {} table.
 
     Parameters:
@@ -1334,11 +1334,14 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
     if parsed_data == -1:
         return
     self._c_tbl.add_entry(parsed_keys, parsed_data)
-        '''.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
+        '''
+
+        code = code_str.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
         add_method = self._set_dynamic_method(code, method_name)
         self._adds["addwithnoaction"] = (add_method, param_list)
 
-    def _create_set_default_with_action(self, data_fields, action_name):
+    # Generating set_default_with_<action> APIs dynamically
+    def _create_set_default_with_action(self, data_fields, action_name, code_str=None):
         if "set_default" not in self._c_tbl.supported_commands:
             return
 
@@ -1350,9 +1353,9 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, data_fields=data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {}):
     """Set default action for {} table with action: {}
 
     Parameters:
@@ -1364,19 +1367,21 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
     if parsed_data == -1:
         return
     self._c_tbl.set_default_entry(parsed_data, b'{}')
-        '''.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
+        '''
+        code = code_str.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
         add_method = self._set_dynamic_method(code, method_name)
 
-    def _create_set_default(self, data_fields):
+    # Generating set_default API dynamically
+    def _create_set_default(self, data_fields, code_str=None):
         method_name = "set_default"
         if method_name not in self._c_tbl.supported_commands or self._c_tbl.has_const_default_action:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, data_fields=data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {}):
     """Set default action for {} table.
 
     Parameters:
@@ -1388,24 +1393,28 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None):
     if parsed_data == -1:
         return
     self._c_tbl.set_default_entry(parsed_data)
-        '''.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
+        '''
+        code = code_str.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
         self._set_dynamic_method(code, method_name)
 
-    def _create_reset_default(self):
+    # Generating reset_default API dynamically
+    def _create_reset_default(self, code_str=None):
         method_name = "reset_default"
         if method_name not in self._c_tbl.supported_commands:
             return
 
-        code = '''
-@target_check_and_set
-def {}(self, pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self):
     """Set default action for {} table.
     """
     self._c_tbl.reset_default_entry()
-        '''.format(method_name, self._name)
+        '''
+        code = code_str.format(method_name, self._name)
         self._set_dynamic_method(code, method_name)
 
-    def _create_mod_with_action(self, key_fields, data_fields, action_name):
+    # Generating mod_with_<action> APIs dynamically
+    def _create_mod_with_action(self, key_fields, data_fields, action_name, code_str=None):
         if "mod" not in self._c_tbl.supported_commands:
             return
 
@@ -1415,9 +1424,9 @@ def {}(self, pipe=None, gress_dir=None, prsr_id=None):
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields, data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, ttl_reset=True):
+        if code_str == None:
+            code_str = '''
+def {}(self, {} ttl_reset=True):
     """Modify entry in {} table using action: {}
 
     Parameters:
@@ -1431,11 +1440,13 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, ttl_reset=True):
         return
 
     self._c_tbl.mod_entry(parsed_keys, parsed_data, b'{}', ttl_reset=ttl_reset)
-        '''.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
+        '''
+        code= code_str.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
         mod_method = self._set_dynamic_method(code, method_name)
         self._mods[full_strname] = (mod_method, param_list)
 
-    def _create_mod_inc_with_action(self, key_fields, data_fields, action_name):
+    # Generating mod_inc_with_<action> APIs dynamically
+    def _create_mod_inc_with_action(self, key_fields, data_fields, action_name, code_str=None):
         if "mod_inc" not in self._c_tbl.supported_commands:
             return
 
@@ -1445,9 +1456,9 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, ttl_reset=True):
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields, data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} mod_flag=0, pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code.str = '''
+def {}(self, {} mod_flag=0):
     """ Incremental Add/Delete items in the fields that are array for the matched entry in {} table.
 
     Parameters:
@@ -1461,20 +1472,22 @@ def {}(self, {} mod_flag=0, pipe=None, gress_dir=None, prsr_id=None):
         return
 
     self._c_tbl.mod_inc_entry(parsed_keys, parsed_data, mod_flag, b'{}')
-        '''.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
+        '''
+        code = code_str.format(method_name, param_str, self._name, full_strname, param_docstring, method_name, parse_key_call, parse_data_call, full_strname, full_strname)
         mod_method = self._set_dynamic_method(code, method_name)
         self._mods_inc[full_strname] = (mod_method, param_list)
 
-    def _create_mod(self, key_fields, data_fields):
+    # Generating mod API dynamically
+    def _create_mod(self, key_fields, data_fields, code_str=None):
         method_name = "mod"
         if method_name not in self._c_tbl.supported_commands:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields, data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, ttl_reset=True):
+        if code_str == None:
+            code_str = '''
+def {}(self, {} ttl_reset=True):
     """Modify any field in the entry at once in {} table.
 
     Parameters:
@@ -1488,20 +1501,22 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, ttl_reset=True):
         return
 
     self._c_tbl.mod_entry(parsed_keys, parsed_data, ttl_reset=ttl_reset)
-        '''.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
+        '''
+        code = code_str.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
         mod_method = self._set_dynamic_method(code, method_name)
         self._mods[""] = (mod_method, param_list)
 
-    def _create_mod_inc(self, key_fields, data_fields):
+    # Generating mod_inc API dynamically
+    def _create_mod_inc(self, key_fields, data_fields, code_str=None):
         method_name = "mod_inc"
         if method_name not in self._c_tbl.supported_commands:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields, data_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} mod_flag=0, pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {} mod_flag=0):
     """ Incremental Add/Delete items in the fields that are array for the matched entry in {} table.
 
     Parameters:
@@ -1515,20 +1530,22 @@ def {}(self, {} mod_flag=0, pipe=None, gress_dir=None, prsr_id=None):
         return
 
     self._c_tbl.mod_inc_entry(parsed_keys, parsed_data, mod_flag)
-        '''.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
+        '''
+        code = code_str.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
         mod_method = self._set_dynamic_method(code, method_name)
         self._mods_inc[""] = (mod_method, param_list)
 
-    def _create_del(self, key_fields):
+    # Generating delete API dynamically
+    def _create_del(self, key_fields, code_str=None):
         method_name = "delete"
         if method_name not in self._c_tbl.supported_commands:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields=key_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, handle=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {} handle=None):
     """Delete entry from {} table.
 
     Parameters:
@@ -1539,20 +1556,22 @@ def {}(self, {} pipe=None, gress_dir=None, prsr_id=None, handle=None):
         return
 
     self._c_tbl.del_entry(parsed_keys, entry_handle=handle)
-        '''.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
+        '''
+        code = code_str.format(method_name, param_str, self._name, param_docstring, method_name, parse_key_call, parse_data_call)
         del_method = self._set_dynamic_method(code, method_name)
         self._dels.append((del_method, param_list))
 
-    def _create_get(self, key_fields):
+    # Generating get API dynamically
+    def _create_get(self, key_fields, code_str=None):
         method_name = "get"
         if method_name not in self._c_tbl.supported_commands:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields=key_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} regex=False, return_ents=True, print_ents=True, table=False, from_hw=False, pipe=None, gress_dir=None, prsr_id=None, handle=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {} regex=False, return_ents=True, print_ents=True, table=False, from_hw=False, handle=None):
     """Get entry from {} table.
     If regex param is set to True, perform regex search on key fields.
     When regex is true, default for each field is to accept all.
@@ -1582,20 +1601,22 @@ def {}(self, {} regex=False, return_ents=True, print_ents=True, table=False, fro
     if return_ents:
         return objs
     return
-        '''.format(method_name, param_str, self._name, param_docstring, parse_key_call, parse_key_call, method_name, parse_key_call, parse_data_call)
+        '''
+        code = code_str.format(method_name, param_str, self._name, param_docstring, parse_key_call, parse_key_call, method_name, parse_key_call, parse_data_call)
         get_method = self._set_dynamic_method(code, method_name)
         self._gets.append((get_method, param_list))
 
-    def _create_get_handle(self, key_fields):
+    # Generating get_handle API dynamically
+    def _create_get_handle(self, key_fields, code_str=None):
         method_name = "get_handle"
         if method_name not in self._c_tbl.supported_commands:
             return
 
         param_str, param_docstring, parse_key_call, parse_data_call, param_list = self._make_core_method_strs(method_name, key_fields=key_fields)
 
-        code = '''
-@target_check_and_set
-def {}(self, {} regex=False, return_ents=True, print_ents=True, table=False, from_hw=False, pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, {} regex=False, return_ents=True, print_ents=True, table=False, from_hw=False):
     """Get entry handle for specific key from {} table.
     If regex param is set to True, perform regex search on key fields.
     When regex is true, default for each field is to accept all.
@@ -1626,25 +1647,25 @@ def {}(self, {} regex=False, return_ents=True, print_ents=True, table=False, fro
     if return_ents:
         return objs
     return
-        '''.format(method_name, param_str, self._name, param_docstring,  parse_key_call, parse_key_call, method_name, parse_key_call, parse_data_call)
+        '''
+        code = code_str.format(method_name, param_str, self._name, param_docstring,  parse_key_call, parse_key_call, method_name, parse_key_call, parse_data_call)
         get_method = self._set_dynamic_method(code, method_name)
         self._gets.append((get_method, param_list))
 
-    def _create_get_key(self):
+    # Generating get_key API dynamically
+    def _create_get_key(self, code_str=None):
         method_name = "get_key"
         if method_name not in self._c_tbl.supported_commands:
             return
-
-        code = '''
-@target_check_and_set
-def {}(self, handle, return_ent=True, print_ent=True, from_hw=False, pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code = '''
+def {}(self, handle, return_ent=True, print_ent=True, from_hw=False):
     """Get entry key from {} table by entry handle.
 
     Parameters:
     handle: type=UINT64 size=32
     from_hw: default=False
     print_ents: default=True
-    pipe: default=None (use global setting)
     """
     if handle < 0 or handle >= 2**(sizeof(c_uint32)*8):
         return -1
@@ -1652,32 +1673,35 @@ def {}(self, handle, return_ent=True, print_ent=True, from_hw=False, pipe=None, 
     if return_ent:
         return objs
     return
-        '''.format(method_name, self._name)
+        '''
+        code = code_str.format(method_name, self._name)
         self._set_dynamic_method(code, method_name)
 
-    def _create_get_default(self):
+    # Generating get_default API dynamically
+    def _create_get_default(self, code_str=None):
         method_name = "get_default"
         if method_name not in self._c_tbl.supported_commands:
             return
 
-        code = '''
-@target_check_and_set
-def {}(self, return_ent=True, print_ent=True, from_hw=False, pipe=None, gress_dir=None, prsr_id=None):
+        if code_str == None:
+            code_str = '''
+def {}(self, return_ent=True, print_ent=True, from_hw=False):
     """Get default entry from {} table.
 
     Parameters:
     from_hw: default=False
     print_ents: default=True
     table: default=False
-    pipe: default=None (use global setting)
     """
     objs = self._c_tbl.get_default_entry(print_entry=print_ent, from_hw=from_hw)
     if return_ent:
         return objs
     return
-        '''.format(method_name, self._name)
+        '''
+        code = code_str.format(method_name, self._name)
         self._set_dynamic_method(code, method_name)
 
+    # Generating entry_with_<action> APIs dynamically
     def _create_entry_with_action(self, key_fields, data_fields, action_name):
         # The purpose of this function is for the user to be able to create an
         # and entry object and then eventually add it to the table or potentially
@@ -2150,9 +2174,7 @@ class TdiCli:
     # targets to override this list with their fixed nodes.
     fixed_nodes = []
 
-    def start_tdi(self, in_fd, out_fd, install_dir, dev_id_list, udf=None, interactive=False, cIntf_cls=None):
-        global install_directory
-        install_directory = install_dir
+    def start_tdi(self, in_fd, out_fd, dev_id_list, udf=None, interactive=False, cIntf_cls=None):
         inf, outf = set_io(in_fd, out_fd)
 
         # set level to DEBUG to see the debug infomration


### PR DESCRIPTION
Same changes as in https://github.com/p4lang/tdi/pull/91
Creating new PR as the old one was reverted.

**Approach used to bifurcate dynamic APIs into target independent and dependents parts:**

Target derives TDILeaf and overrides dynamic API generation functions(eg: _create_add_with_action). In these functions, code_str is set with the code that is to be used to generate APIs. The target then calls the corresponding parent class function, which creates and adds the dynamic function.