### PR TITLE
Fix for getValue for string keyfield

### DIFF
--- a/include/tdi/common/c_frontend/tdi_table.h
+++ b/include/tdi/common/c_frontend/tdi_table.h
@@ -396,32 +396,6 @@ tdi_status_t tdi_table_key_reset(const tdi_table_hdl *table_hdl,
  */
 tdi_status_t tdi_table_key_deallocate(tdi_table_key_hdl *key_hdl);
 
-/**
- * @brief Get size of array of allowed choices for string
- *
- * @param[in] table_hdl Table object
- * @param[in] field_id Field ID
- * @param[out] num Array size
- *
- * @return Status of the API call
- */
-tdi_status_t tdi_key_field_num_allowed_choices_get(
-    const tdi_table_hdl *table_hdl, const tdi_id_t field_id, uint32_t *num);
-
-/**
- * @brief Get array of allowed choices for string
- *
- * @param[in] table_hdl Table object
- * @param[in] field_id Field ID
- * @param[out] choices Array of char ptrs. The array of ptrs needs to
- * be allocated by user based upon the size from num API
- *
- * @return Status of the API call
- */
-tdi_status_t tdi_key_field_allowed_choices_get(const tdi_table_hdl *table_hdl,
-                                               const tdi_id_t field_id,
-                                               const char *choices[]);
-
 /******************** Data APIs *******************/
 
 /**

--- a/include/tdi/common/c_frontend/tdi_table_info.h
+++ b/include/tdi/common/c_frontend/tdi_table_info.h
@@ -20,11 +20,11 @@
 #ifndef _TDI_TABLE_INFO_H
 #define _TDI_TABLE_INFO_H
 
-#include <tdi/common/tdi_defs.h>
+#include <tdi/common/c_frontend/tdi_attributes.h>
+#include <tdi/common/c_frontend/tdi_operations.h>
 #include <tdi/common/c_frontend/tdi_table_data.h>
 #include <tdi/common/c_frontend/tdi_table_key.h>
-#include <tdi/common/c_frontend/tdi_operations.h>
-#include <tdi/common/c_frontend/tdi_attributes.h>
+#include <tdi/common/tdi_defs.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -773,6 +773,32 @@ tdi_status_t tdi_table_num_api_supported(
 tdi_status_t tdi_table_api_supported(const tdi_table_info_hdl *table_info_hdl,
                                      tdi_table_api_type_e *apis,
                                      uint32_t *num_returned);
+
+/**
+ * @brief Get size of array of allowed choices for string
+ *
+ * @param[in] table_hdl Table object
+ * @param[in] field_id Field ID
+ * @param[out] num Array size
+ *
+ * @return Status of the API call
+ */
+tdi_status_t tdi_key_field_num_allowed_choices_get(
+    const tdi_table_info_hdl *table_hdl, const tdi_id_t field_id, uint32_t *num);
+
+/**
+ * @brief Get array of allowed choices for string
+ *
+ * @param[in] table_hdl Table object
+ * @param[in] field_id Field ID
+ * @param[out] choices Array of char ptrs. The array of ptrs needs to
+ * be allocated by user based upon the size from num API
+ *
+ * @return Status of the API call
+ */
+tdi_status_t tdi_key_field_allowed_choices_get(const tdi_table_info_hdl *table_hdl,
+                                               const tdi_id_t field_id,
+                                               const char *choices[]);
 
 /**
  * @brief Get size of list of all the allowed values that a particular field can

--- a/src/c_frontend/tdi_table_key_c.cpp
+++ b/src/c_frontend/tdi_table_key_c.cpp
@@ -152,6 +152,7 @@ tdi_status_t tdi_key_field_get_value_string_size(
   std::string str;
   tdi::KeyFieldValueExact<std::string> keyFieldValue(str);
   tdi_status_t status = key->getValue(field_id, &keyFieldValue);
+  str = keyFieldValue.value_;
   *str_size = str.size();
   return status;
 }
@@ -163,6 +164,7 @@ tdi_status_t tdi_key_field_get_value_string(const tdi_table_key_hdl *key_hdl,
   std::string str(value);
   tdi::KeyFieldValueExact<std::string> keyFieldValue(str);
   tdi_status_t status = key->getValue(field_id, &keyFieldValue);
+  str = keyFieldValue.value_;
   strncpy(value, str.c_str(), str.size());
   return status;
 }


### PR DESCRIPTION
Fix for a couple of minor issues:
1. Bug in tdi_key_field_get_value_string_size and tdi_key_field_get_value_string
1. Moving tdi_key_field_num_allowed_choices_get/tdi_key_field_allowed_choices_get to from tdi_table.h to tdi_table_info.h
    This is to be consistent with other similar APIs

