### PR TITLE
minor fix related to string_choices

### DIFF
--- a/tdi_python/tdicli.py
+++ b/tdi_python/tdicli.py
@@ -1042,11 +1042,11 @@ Available Commands:
 
     def _init_string_choices(self):
         if len(self._c_tbl.string_choices) > 0:
-            string_choices = {}
+            self.string_choices = {}
             for name, choices in self._c_tbl.string_choices.items():
-                string_choices[name] = []
-                string_choices[name].extend(choices)
-            self._children["string_choices"] = string_choices
+                self.string_choices[name] = []
+                self.string_choices[name].extend(choices)
+            self._children["string_choices"] = self.string_choices
 
     """
     The following functions create appropriate add, modify, delete, get, dump


### PR DESCRIPTION
**Issue: string_choices attribute is not available at intermediate nodes:**
```
tdi_python> tdi.tna_idletimeout.pipe.SwitchIngress.dmac.string_choices

---------------------------------------------------------------------------

AttributeError                            Traceback (most recent call last)

<ipython-input-28-217667697767> in <module>

----> 1 tdi.tna_idletimeout.pipe.SwitchIngress.dmac.string_choices
AttributeError: 'TDILeafTofino' object has no attribute 'string_choices'
```
**Fix: Added string_choiceses as a member of TDILeaf** 