### PR TITLE
Few fixes for string type input

### DIFF
--- a/include/tdi/common/c_frontend/tdi_table_data.h
+++ b/include/tdi/common/c_frontend/tdi_table_data.h
@@ -175,6 +175,21 @@ tdi_status_t tdi_data_field_set_string(tdi_table_data_hdl *data_hdl,
                                         const char *val);
 
 /**
+ * @brief Set value based on size. Valid only on fields with string type
+ *
+ * @param[in] data_hdl          Data object handle
+ * @param[in] field_id          Field ID
+ * @param[in] val               String value
+ * @param[in] s                 Size of string value
+ *
+ * @return Status of the API call
+ */
+tdi_status_t tdi_data_field_set_string_with_size(tdi_table_data_hdl *data_hdl,
+                                                  const tdi_id_t field_id,
+                                                  const char *val,
+                                                  const size_t s);
+
+/**
  * @brief Get value. Only valid on fields of size <= 64 bits
  *
  * @param[in] data_hdl          Data object handle

--- a/include/tdi/common/tdi_table_data.hpp
+++ b/include/tdi/common/tdi_table_data.hpp
@@ -196,12 +196,25 @@ class TableData {
    * @brief Set value. Valid only on fields with string type
    *
    * @param[in] field_id Field ID
-   * @param[in] value String value
+   * @param[in] str String value
    *
    * @return Status of the API call
    */
   virtual tdi_status_t setValue(const tdi_id_t &field_id,
                                 const std::string &str);
+
+  /**
+   * @brief Set value based on size. Valid only on fields with string type
+   *
+   * @param[in] field_id Field ID
+   * @param[in] str String value
+   * @param[in] s Size of string value
+   *
+   * @return Status of the API call
+   */
+  virtual tdi_status_t setValue(const tdi_id_t &field_id,
+                                const std::string &str,
+                                const size_t &size);
 
   /** @} */  // End of group Set APIs
 

--- a/src/c_frontend/tdi_table_data_c.cpp
+++ b/src/c_frontend/tdi_table_data_c.cpp
@@ -124,6 +124,24 @@ tdi_status_t tdi_data_field_set_string(tdi_table_data_hdl *data_hdl,
   return data_field->setValue(field_id, str_val);
 }
 
+tdi_status_t tdi_data_field_set_string_with_size(tdi_table_data_hdl *data_hdl,
+                                                  const tdi_id_t field_id,
+                                                  const char *val,
+                                                  const size_t s) {
+  auto data_field = reinterpret_cast<tdi::TableData *>(data_hdl);
+  std::string str_val = {0};
+  if (s > 0) {
+      /* we don't append directly as the data/value would be appended to NULL,
+       * instead, we want to assign the same value to str_val which val
+       * holds. */
+      str_val = val[0];
+      for (int i = 1; i < (int)s; i++) {
+          str_val += val[i];
+      }
+  }
+  return data_field->setValue(field_id, str_val, s);
+}
+
 tdi_status_t tdi_data_field_get_value(const tdi_table_data_hdl *data_hdl,
                                        const tdi_id_t field_id,
                                        uint64_t *val) {

--- a/src/tdi_table_data.cpp
+++ b/src/tdi_table_data.cpp
@@ -82,6 +82,13 @@ tdi_status_t TableData::setValue(const tdi_id_t & /*field_id*/,
   return TDI_NOT_SUPPORTED;
 }
 
+tdi_status_t TableData::setValue(const tdi_id_t & /*field_id*/,
+                                 const std::string & /*str*/,
+                                 const size_t & /*size*/) {
+  LOG_ERROR("%s:%d Not supported", __func__, __LINE__);
+  return TDI_NOT_SUPPORTED;
+}
+
 tdi_status_t TableData::getValue(const tdi_id_t & /*field_id*/,
                                  uint64_t * /*value*/) const {
   LOG_ERROR("%s:%d Not supported", __func__, __LINE__);

--- a/tdi_python/tdiTable.py
+++ b/tdi_python/tdiTable.py
@@ -1109,8 +1109,13 @@ class TdiTable:
                 value = c_bool(content[name])
                 sts = self._cintf.get_driver().tdi_data_field_set_bool(data_handle, info.id, value)
             if self.data_type_cls.data_type_str(info.data_type) == "STRING":
-                value = c_char_p(content[name].encode('ascii'))
-                sts = self._cintf.get_driver().tdi_data_field_set_string(data_handle, info.id, value)
+                string = content[name]
+                if string[0:2] == "0x":
+                    bytestr = bytes.fromhex(string[2:])
+                else:
+                    bytestr = string.encode('ascii')
+                value = c_char_p(bytestr)
+                sts = self._cintf.get_driver().tdi_data_field_set_string_with_size(data_handle, info.id, value, len(bytestr))
             """
             if self.data_type_cls.data_type_str(info.data_type) == "CONTAINER":
                 cont_list_len = len(content[name])


### PR DESCRIPTION
1. If the input string is mentioned as hex, take the hex representation otherwise take the input bytes and convert them to ASCII for further processing.

2. Pass the length of input bytes/string. Use this length to copy and process the string bytes. This will mitigate the risk of buffer overflows, memory corruption or information leakage and other string issues which might occur while processing string without knowning it's length. The fix will also enable to pass and have NULL char and other special chars as part of string.